### PR TITLE
Stop using deprecated bare variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,13 @@
     value: '{{ item.value }}'
     state: 'present'
     reload: True
-  with_dict: swapfile_sysctl_map
+  with_dict: '{{ swapfile_sysctl_map }}'
   when: swapfile_sysctl_map|d()
 
 - name: Disable swap files when requested
   shell: test -f {{ item.path | d(item) }} && swapoff {{ item.path | d(item) }} || true
   changed_when: False
-  with_items: swapfile_files
+  with_items: '{{ swapfile_files }}'
   when: ((swapfile_files|d() and item.state|d() and item.state == 'absent') and
          (ansible_local|d() and (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
           (ansible_local.cap12s.enabled | bool and 'cap_sys_admin' in ansible_local.cap12s.list)))))
@@ -22,7 +22,7 @@
   file:
     path: '{{ item.path | d(item) }}'
     state: 'absent'
-  with_items: swapfile_files
+  with_items: '{{ swapfile_files }}'
   when: swapfile_files|d() and item.state|d() and item.state == 'absent'
 
 - name: Create swap files
@@ -35,7 +35,7 @@
   args:
     creates: '{{ item.path | d(item) }}'
   register: swapfile_register_allocation
-  with_items: swapfile_files
+  with_items: '{{ swapfile_files }}'
   when: (swapfile_files|d() and
          (item.state is undefined or item.state != 'absent'))
 
@@ -46,21 +46,21 @@
     owner: 'root'
     group: 'root'
     mode: '0600'
-  with_items: swapfile_files
+  with_items: '{{ swapfile_files }}'
   when: (swapfile_files|d() and
          (item.state is undefined or item.state != 'absent'))
 
 - name: Initialize swap files
   command: mkswap {{ item.item.path | d(item.item) }}
   register: swapfile_register_init
-  with_items: swapfile_register_allocation.results
+  with_items: '{{ swapfile_register_allocation.results }}'
   when: ((swapfile_files|d() and swapfile_register_allocation|d() and
           item.changed | bool) and
          (item.state is undefined or item.state != 'absent'))
 
 - name: Enable swap files
   command: swapon -p {{ item.item.priority | d(swapfile_priority) }} {{ item.item.path | d(item.item) }}
-  with_items: swapfile_register_allocation.results
+  with_items: '{{ swapfile_register_allocation.results }}'
   when: ((swapfile_files|d() and swapfile_register_allocation|d() and item.changed | bool) and
          (item.state is undefined or item.state != 'absent') and
           (ansible_local|d() and (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
@@ -75,6 +75,6 @@
     dump:   '0'
     passno: '0'
     state:  '{{ item.state | d("present") }}'
-  with_items: swapfile_files
+  with_items: '{{ swapfile_files }}'
   when: swapfile_files|d()
 


### PR DESCRIPTION
Ansible 2.0 deprecates using bare variables in with_ loops:
https://docs.ansible.com/ansible/porting_guide_2.0.html#deprecated

These changes get rid of the deprecation warnings.