### PR TITLE
Move management of kernel parameters to debops.sysctl

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,5 @@
+.. _swapfile__ref_changelog:
+
 Changelog
 =========
 
@@ -15,6 +17,23 @@ The current role maintainer_ is drybjed_
 ----------------------------------------
 
 .. _debops.swapfile master: https://github.com/debops/ansible-swapfile/compare/v0.2.0...master
+
+Added
+~~~~~
+
+- Add :ref:`swapfile__ref_upgrade_nodes`. [ypid_]
+
+Removed
+~~~~~~~
+
+- Management of kernel parameters is now handled by debops.sysctl_.
+  The related variables like ``swapfile__swappiness`` and
+  ``swapfile__cache_pressure`` have no effect anymore.
+  Refer to :ref:`swapfile__ref_upgrade_nodes_v0.4.0` for details.
+  [ypid_]
+
+- Remove deprecated Ansible inventory group ``debops_service_swapfile``. Refer
+  to the :ref:`swapfile__ref_getting_started` guide. [ypid_]
 
 
 `debops.swapfile v0.3.0`_ - 2016-10-29

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changelog
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__
 and `human-readable changelog <http://keepachangelog.com/en/0.3.0/>`__.
 
-The current role maintainer_ is drybjed_
+The current role maintainer_ is drybjed_.
 
 
 `debops.swapfile master`_ - unreleased

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ manage kernel parameters related to how swap is used by the system.
 
 Note that this role can not setup a swap file on a BTRFS filesystem.
 
+Refer to [debops.sysctl] for paging and swapping related kernel settings.
+[debops.sysctl]: https://github.com/debops/ansible-sysctl
+
 ### Installation
 
 This role requires at least Ansible `v2.1.0`. To install it, run:

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -1,0 +1,24 @@
+.. _swapfile__ref_upgrade_nodes:
+
+Upgrade notes
+=============
+
+The upgrade notes only describe necessary changes that you might need to make
+to your setup in order to use a new role release. Refer to the
+:ref:`swapfile__ref_changelog` for more details about what has changed.
+
+.. _swapfile__ref_upgrade_nodes_v0.4.0:
+
+Upgrade from v0.3.0 to v0.4.0
+-----------------------------
+
+Some inventory variables have been renamed so you might need to update your
+inventory.
+This script can come in handy to do this:
+
+.. literalinclude:: scripts/upgrade-from-v0.3.X-to-v0.4.X
+   :language: shell
+
+The script is bundled with this role under
+:file:`./docs/scripts/upgrade-from-v0.3.X-to-v0.4.X` and can be invoked from
+their.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,34 +44,4 @@ swapfile__use_dd: False
 swapfile__files: [ '/swapfile' ]
                                                                    # ]]]
                                                                    # ]]]
-# Kernel parameters [[[
-# ---------------------
-
-# .. envvar:: swapfile__swappiness [[[
-#
-# Set ``vm.swappiness`` kernel parameter.
-swapfile__swappiness: '60'
-
-                                                                   # ]]]
-# .. envvar:: swapfile__cache_pressure [[[
-#
-# Set ``vm.vfs_cache_pressure`` kernel parameter.
-swapfile__cache_pressure: '100'
-
-                                                                   # ]]]
-# .. envvar:: swapfile__sysctl_file [[[
-#
-# Name of the file with kernel parameters.
-swapfile__sysctl_file: '/etc/sysctl.d/30-debops.swapfile.conf'
-
-                                                                   # ]]]
-# .. envvar:: swapfile__sysctl_map [[[
-#
-# YAML dictionary with kernel parameters to set. Change it to an empty dict
-# to disable the kernel configuration.
-swapfile__sysctl_map:
-  'vm.swappiness': '{{ swapfile__swappiness }}'
-  'vm.vfs_cache_pressure': '{{ swapfile__cache_pressure }}'
-                                                                   # ]]]
-                                                                   # ]]]
                                                                    # ]]]

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,3 +1,5 @@
+.. _swapfile__ref_getting_started:
+
 Getting started
 ===============
 
@@ -13,20 +15,11 @@ To enable swap files on a host, it needs to be added to the
     [debops_service_swapfile]
     hostname
 
-The default configuration will create a 512 MB :file:`/swapfile` and will make sure
-that it's added in :file:`/etc/fstab`.
-
 Example playbook
 ----------------
 
-Here's an example playbook you can use to configure swap on a host::
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.swapfile`` role:
 
-    ---
-    - name: Manage swap
-      hosts: 'debops_service_swapfile'
-      become: True
-
-      roles:
-
-        - role: debops.swapfile
-
+.. literalinclude:: playbooks/swapfile.yml
+   :language: yaml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Ansible role: debops.swapfile
    defaults-detailed
    copyright
    changelog
+   upgrade
 
 ..
  Local Variables:

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,10 +1,14 @@
 Introduction
 ============
 
+.. include:: includes/all.rst
+
 This Ansible role lets you manage one or multiple swap files. You can also
 manage kernel parameters related to how swap is used by the system.
 
 Note that this role can not setup a swap file on a BTRFS filesystem.
+
+Refer to debops.sysctl_ for paging and swapping related kernel settings.
 
 Installation
 ~~~~~~~~~~~~

--- a/docs/playbooks/swapfile.yml
+++ b/docs/playbooks/swapfile.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Configure swap files
+  hosts: [ 'debops_service_swapfile' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.swapfile
+      tags: [ 'role::swapfile' ]

--- a/docs/scripts/upgrade-from-v0.3.X-to-v0.4.X
+++ b/docs/scripts/upgrade-from-v0.3.X-to-v0.4.X
@@ -1,0 +1,9 @@
+#!/bin/bash
+## Upgrade inventory variables for migration from debops.swapfile v0.3.X to v0.4.X.
+## The script is idempotent.
+
+git ls-files -z "$(git rev-parse --show-toplevel)" | xargs --null -I '{}' find '{}' -type f -print0 \
+ | xargs --null sed --in-place --regexp-extended '
+     s/swapfile__swappiness/sysctl__swappiness/g;
+     s/swapfile__cache_pressure/sysctl__vfs_cache_pressure/g;
+   '

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -1,0 +1,1 @@
+.. include:: ../UPGRADE.rst

--- a/meta/ansigenome.yml
+++ b/meta/ansigenome.yml
@@ -24,3 +24,6 @@ ansigenome_info:
     manage kernel parameters related to how swap is used by the system.
 
     Note that this role can not setup a swap file on a BTRFS filesystem.
+
+    Refer to [debops.sysctl] for paging and swapping related kernel settings.
+    [debops.sysctl]: https://github.com/debops/ansible-sysctl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Configure kernel parameters
-  sysctl:
-    sysctl_file: '{{ swapfile__sysctl_file }}'
-    name: '{{ item.key }}'
-    value: '{{ item.value }}'
-    state: 'present'
-    reload: True
-  with_dict: '{{ swapfile__sysctl_map }}'
-
 - name: Disable swap files when requested
   shell: test -f {{ item.path | d(item) }} && swapoff {{ item.path | d(item) }} || true
   changed_when: False
@@ -70,3 +61,8 @@
     state: 'absent'
   with_items: '{{ swapfile__files }}'
   when: (item.state|d("present") == 'absent')
+
+- name: Remove legacy kernel parameters file
+  file:
+    path: '{{ swapfile__sysctl_file|d("/etc/sysctl.d/30-debops.swapfile.conf") }}'
+    state: 'absent'


### PR DESCRIPTION
Moved to: https://github.com/debops/ansible-sysctl/pull/5
Closes: #8